### PR TITLE
[I] update token for authentication when server ask to store token

### DIFF
--- a/ZetaPushSwift/Core/Client/ClientHelper+Handshake.swift
+++ b/ZetaPushSwift/Core/Client/ClientHelper+Handshake.swift
@@ -54,6 +54,10 @@ open class AbstractHandshake {
   func getAuthData() -> [String: Any] {
     fatalError("This method must be overridden")
   }
+  
+  func update(token: String) {
+    fatalError("This method must be overridden")
+  }
 }
 
 // MARK: - TokenHandshake
@@ -69,6 +73,10 @@ open class TokenHandshake: AbstractHandshake {
   
   override func getAuthData() -> [String: Any] {
     return ["token": token]
+  }
+  
+  override func update(token: String) {
+    self.token = token
   }
 }
 
@@ -90,6 +98,10 @@ open class CredentialsHanshake: AbstractHandshake {
       "login": login,
       "password": password
     ]
+  }
+  
+  override func update(token: String) {
+    self.login = token
   }
 }
 

--- a/ZetaPushSwift/Core/Client/ClientHelper.swift
+++ b/ZetaPushSwift/Core/Client/ClientHelper.swift
@@ -35,7 +35,7 @@ open class ClientHelper: NSObject, CometdClientDelegate {
   
   var logLevel: XCGLogger.Level = .severe
   
-  fileprivate var authentication: AbstractHandshake
+  private(set) var authentication: AbstractHandshake
   let cometdClient: CometdClient
   
   open weak var delegate:ClientHelperDelegate?
@@ -146,6 +146,7 @@ open class ClientHelper: NSObject, CometdClientDelegate {
   private func configureCometdClient() {
     cometdClient.configure(url: server)
     let handshakeFields = authentication.getHandshakeFields(self)
+    self.log.debug("authentification = \(authentication)")
     cometdClient.connectHandshake(handshakeFields)
   }
   
@@ -208,14 +209,13 @@ open class ClientHelper: NSObject, CometdClientDelegate {
     log.setup(level: logLevel)
   }
   
-  /*
-   Must be overriden by ClientHelper descendants
-   */
-  func storeHandshakeToken(_ authenticationDict: NSDictionary) { }
-  /*
-   Must be overriden by ClientHelper descendants
-   */
-  func eraseHandshakeToken() { }
+  func storeHandshakeToken(_ authenticationDict: NSDictionary) {
+    preconditionFailure("This method must be overridden")
+  }
+  
+  func eraseHandshakeToken() {
+    preconditionFailure("This method must be overridden")
+  }
   
   open func getClientId() -> String {
     return cometdClient.getCometdClientId()

--- a/ZetaPushSwift/Core/Client/smart/ZetaPushSmartClient.swift
+++ b/ZetaPushSwift/Core/Client/smart/ZetaPushSmartClient.swift
@@ -79,6 +79,7 @@ open class ZetaPushSmartClient: ClientHelper {
     defaults.set(self.getSandboxId(), forKey: zetaPushDefaultKeys.sandboxId)
     if let token = authenticationDict["token"] as? String {
       defaults.set(token, forKey: zetaPushDefaultKeys.token)
+      authentication.update(token: token)
     }
     if let publicToken = authenticationDict["publicToken"] as? String  {
       defaults.set(publicToken, forKey: zetaPushDefaultKeys.publicToken)

--- a/ZetaPushSwift/Core/Client/weak/ZetaPushWeakClient.swift
+++ b/ZetaPushSwift/Core/Client/weak/ZetaPushWeakClient.swift
@@ -49,6 +49,7 @@ open class ZetaPushWeakClient: ClientHelper {
     
     if let token = authenticationDict["token"] as? String {
       defaults.set(token, forKey: zetaPushDefaultKeys.token)
+      authentication.update(token: token)
     }
     if let publicToken = authenticationDict["publicToken"] as? String {
       defaults.set(publicToken, forKey: zetaPushDefaultKeys.publicToken)


### PR DESCRIPTION
During the first init of SmartClient or WeakClient, the authentication is init with a configuration. But during the first connection the server respond with some token (public or private). So to persist the connection and retry a connection after losing the server, we need to update previous created connection with this tokens.